### PR TITLE
Banned users' messages do not show up in chat.

### DIFF
--- a/app/channels/message_channel.rb
+++ b/app/channels/message_channel.rb
@@ -3,12 +3,11 @@
 # Receive messages from JavaScript in the browser.
 class MessageChannel < ApplicationCable::Channel
   def receive(data)
-    Message.create!(
+    Message.create_message!(
       channel: current_user.username.downcase,
       from_username: data['from_username'],
       content: data['content'],
-      kind: data['kind']&.to_sym,
-      status: Message.default_status_for(data['kind'].to_sym)
+      kind: data['kind']&.to_sym
     )
   end
 end

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -50,6 +50,11 @@ class MessageTest < ActiveSupport::TestCase
     assert_not_includes Message.expired, ask
   end
 
+  test 'messages are from a banned user' do
+    message = Message.create_message!(channel: 'ChaelCodes', from_username: 'PretzelRocks', content: 'Lol, is a song', kind: 'chat')
+    assert message.nil?
+  end
+
   test 'activating one message inactivates any other active messages' do
     messages(:ask).update(status: :active)
     assert messages(:ask_active).inactive?


### PR DESCRIPTION
# Description
Bot users like PretzelRocks, StreamElements, and Streamlabs will probably never be featured in the overlay, so exclude their noise from chat.

# Changes
Move to use a Factory that creates Messages for us, and excludes BANNED_USERS. We can extend this to include user-submitted banned users as well.