### PR TITLE
RFC:  Use Gist for custom CSS.

### DIFF
--- a/app/javascript/controllers/custom_css_controller.js
+++ b/app/javascript/controllers/custom_css_controller.js
@@ -1,0 +1,21 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+	static targets = ['style'];
+	connect() {
+		fetch(this.data.get('url'))
+			.then((resp) => {
+				if (!resp.ok) {
+					alert("Error fetching custom CSS: " + resp.status);
+				}
+				return resp;
+			})
+			.catch((error) => {
+				console.log(error);
+			})
+			.then(data => data.text())
+			.then((content) => {
+				this.styleTarget.innerText = content;
+			});
+	}
+}

--- a/app/jobs/user_gist_deversion_job.rb
+++ b/app/jobs/user_gist_deversion_job.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'uri'
+
+# Removes the version from a gist URL:
+# https://gist.githubusercontent.com/exegeteio/d5b60958ee4615e839354a6ee2ead5c7/raw/b2aab565424a5f0aefe810f6b3dafaef01f6f8e3/number-two.css
+# Becomes...
+# https://gist.githubusercontent.com/exegeteio/d5b60958ee4615e839354a6ee2ead5c7/raw/number-two.css
+class UserGistDeversionJob < ApplicationJob
+  queue_as :default
+
+  @@gist_urls = %w[
+    gist.githubusercontent.com
+  ]
+
+  def perform(user_id)
+    user = User.find(user_id)
+    user.custom_css = deversion_gist_url(user.custom_css)
+    user.save if user.changed?
+  end
+
+  private
+
+  def deversion_gist_url(url)
+    uri = URI.parse(url)
+    return url unless @@gist_urls.include? uri.host
+
+    (_, username, gist_id, raw, _gist_version, gist_filename) = uri.path.split('/')
+    return url unless gist_filename.present?
+
+    ["https://#{uri.host}", username, gist_id, raw, gist_filename].join('/')
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,9 @@ class User < ApplicationRecord
   # Broadcast changes.  Mostly for CSS.
   broadcasts
 
+  # Deversion Gist URL after update.
+  after_update :gist_deversion
+
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
       user.email = auth.info.email
@@ -47,6 +50,10 @@ class User < ApplicationRecord
 
   def login
     @login || username || email
+  end
+
+  def gist_deversion
+    UserGistDeversionJob.perform_later(id)
   end
 
   def self.find_for_database_authentication(warden_conditions)

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,8 +1,11 @@
 <div id="<%= dom_id(user) %>">
   <% if user.custom_css.present? %>
-    <style>
-      <%= user.custom_css %>
-    </style>
+    <div
+      data-controller="custom-css"
+      data-custom-css-url="<%= user.custom_css %>"
+    >
+      <style data-custom-css-target="style"></style>
+    </div>
   <% else %>
     <%= stylesheet_link_tag 'application', media: 'all' %>
   <% end %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -34,6 +34,21 @@ default:
 non_default:
   email: non_default@wherever.com
   username: non-default
+
+# It is important to tests that this gist URL is the unsanitized version of
+# :with_deversioned_gist.
+with_gist:
+  email: gist@wherever.com
+  username: gist
+  custom_css: https://gist.githubusercontent.com/exegeteio/d5b60958ee4615e839354a6ee2ead5c7/raw/b2aab565424a5f0aefe810f6b3dafaef01f6f8e3/number-two.css
+
+# It is important to tests that this gist URL is the sanitized version of
+# :with_gist.
+with_deversioned_gist:
+  email: deversioned_gist@wherever.com
+  username: deversioned_gist
+  custom_css: https://gist.githubusercontent.com/exegeteio/d5b60958ee4615e839354a6ee2ead5c7/raw/number-two.css
+
 #
 # two: {}
 # column: value

--- a/test/jobs/user_gist_deversion_job_test.rb
+++ b/test/jobs/user_gist_deversion_job_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class UserGistDeversionJobTest < ActiveJob::TestCase
+  test 'does not effect already deversioned gist' do
+    user = users(:with_deversioned_gist)
+    original_url = user.custom_css
+    UserGistDeversionJob.perform_now(user.id)
+    assert_equal original_url, user.reload.custom_css
+  end
+
+  test 'removes versioned part of gist URL' do
+    user = users(:with_gist)
+    original_url = user.custom_css
+    UserGistDeversionJob.perform_now(user.id)
+    assert_not_equal original_url, user.reload.custom_css
+    # This feels a bit hack-ish.  Accepting suggestions to do this better?
+    assert_equal users(:with_deversioned_gist).custom_css, user.reload.custom_css
+  end
+end


### PR DESCRIPTION
This feels a bit hackish, but is the best idea I have so far.  If you have other ideas how to make this happen, please let me know.  

This branch uses JavaScript fetch() to get the content of the Gist and update the page accordingly.  

When copying the Gist Raw URL, by default, includes a specific version identifier which changes after each edit.  There is an ActiveJob for removing that version identifier.  

## What isn’t working?

The Gist is **heavily** cached.  I tried all of my tricks to bust the cache without being evil to GitHub:

- Add a query string with user’s hash().  Still rendered cached version.
- Add a query string with the user’s update_at.   Still cached.
- Add a query string with the current date stamp.  This seemed to work sporadically.  

